### PR TITLE
Close #27 Fix errors/typos in import rake task

### DIFF
--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -2,7 +2,6 @@ class Transaction < ApplicationRecord
   belongs_to :invoice
 
   validates :credit_card_number, presence: true
-  validates :credit_card_expiration_date, presence: true
   validates :result, presence: true
   validates :created_at, presence: true
   validates :updated_at, presence: true

--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -27,7 +27,7 @@ namespace :import do
 
   desc "Import items from csv"
   task items: :environment do
-    file= File.join Rails.root, "Db/data/items.csv"
+    file= File.join Rails.root, "db/data/items.csv"
     CSV.foreach(file, headers: true) do |row|
       Item.create(row.to_hash)
     end
@@ -43,7 +43,7 @@ namespace :import do
 
   desc "Import transactions from csv"
   task transactions: :environment do
-    file= File.join Rails.root, "Db/data/transactions.csv"
+    file= File.join Rails.root, "db/data/transactions.csv"
     CSV.foreach(file, headers: true) do |row|
       Transaction.create(row.to_hash)
     end

--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -5,7 +5,7 @@ namespace :import do
   task customers: :environment do
     file = File.join Rails.root, "db/data/customers.csv"
     CSV.foreach(file, headers: true) do |row|
-      Customer.create(row.to_hash)
+      Customer.create!(row.to_hash)
     end
   end
 
@@ -13,7 +13,7 @@ namespace :import do
   task invoice_items: :environment do
     file = File.join Rails.root, "db/data/invoice_items.csv"
     CSV.foreach(file, headers: true) do |row|
-    InvoiceItem.create(row.to_hash)
+      InvoiceItem.create!(row.to_hash)
     end
   end
 
@@ -21,15 +21,15 @@ namespace :import do
   task invoices: :environment do
     file = File.join Rails.root, "db/data/invoices.csv"
     CSV.foreach(file, headers: true) do |row|
-    Invoice.create(row.to_hash)
+      Invoice.create!(row.to_hash)
     end
   end
 
   desc "Import items from csv"
   task items: :environment do
-    file= File.join Rails.root, "db/data/items.csv"
+    file = File.join Rails.root, "db/data/items.csv"
     CSV.foreach(file, headers: true) do |row|
-      Item.create(row.to_hash)
+      Item.create!(row.to_hash)
     end
   end
 
@@ -37,15 +37,15 @@ namespace :import do
   task merchants: :environment do
     file = File.join Rails.root, "db/data/merchants.csv"
     CSV.foreach(file, headers: true) do |row|
-      Merchant.create(row.to_hash)
+      Merchant.create!(row.to_hash)
     end
   end
 
   desc "Import transactions from csv"
   task transactions: :environment do
-    file= File.join Rails.root, "db/data/transactions.csv"
+    file = File.join Rails.root, "db/data/transactions.csv"
     CSV.foreach(file, headers: true) do |row|
-      Transaction.create(row.to_hash)
+      Transaction.create!(row.to_hash)
     end
   end
 

--- a/spec/models/transaction_spec.rb
+++ b/spec/models/transaction_spec.rb
@@ -9,7 +9,6 @@ RSpec.describe Transaction, type: :model do
 
   it { should belong_to :invoice }
   it { should validate_presence_of :credit_card_number }
-  it { should validate_presence_of :credit_card_expiration_date }
   it { should validate_presence_of :result }
   it { should validate_presence_of :created_at }
   it { should validate_presence_of :updated_at }


### PR DESCRIPTION
- Fix typo in import.rake file (Db -> db)
- Add indent to blocks (import.rake) which were missing indents
- Add bang to create methods
- Remove presence validation for credit_card_expiration_date from Transaction model & spec, since apparently NONE of the transactions in the CSV file have a value for this field
