### PR TITLE
Remove credit_card_expiration_date from transaction serializer

### DIFF
--- a/app/serializers/transaction_serializer.rb
+++ b/app/serializers/transaction_serializer.rb
@@ -1,3 +1,3 @@
 class TransactionSerializer < ActiveModel::Serializer
-  attributes :id, :invoice_id, :credit_card_number, :credit_card_expiration_date, :result, :created_at, :updated_at
+  attributes :id, :invoice_id, :credit_card_number, :result, :created_at, :updated_at
 end


### PR DESCRIPTION
- Remove credit_card_expiration_date from transaction serializer to pass spec harness
