### PR TITLE
Remove .require() from strong params in search controllers

### DIFF
--- a/app/controllers/api/v1/invoice_items/search_controller.rb
+++ b/app/controllers/api/v1/invoice_items/search_controller.rb
@@ -1,20 +1,20 @@
 class Api::V1::InvoiceItems::SearchController < ApplicationController
   respond_to :json
-  
+
   def index
     @invoice_items = InvoiceItem.where(invoice_item_params)
     respond_with @invoice_items
   end
-  
+
   def show
     @invoice_item = InvoiceItem.find_by(invoice_item_params)
     respond_with @invoice_item
   end
-  
+
   private
-  
+
   def invoice_item_params
-    params.require(:invoice_item).permit(
+    params.permit(
       :id,
       :invoice_id,
       :item_id,

--- a/app/controllers/api/v1/invoices/search_controller.rb
+++ b/app/controllers/api/v1/invoices/search_controller.rb
@@ -1,20 +1,20 @@
 class Api::V1::Invoices::SearchController < ApplicationController
   respond_to :json
-  
+
   def index
     @invoices = Invoice.where(invoice_params)
     respond_with @invoices
   end
-  
+
   def show
     @invoice = Invoice.find_by(invoice_params)
     respond_with @invoice
   end
-  
+
   private
-  
+
   def invoice_params
-    params.require(:invoice).permit(
+    params.permit(
       :id,
       :customer_id,
       :merchant_id,

--- a/app/controllers/api/v1/items/search_controller.rb
+++ b/app/controllers/api/v1/items/search_controller.rb
@@ -1,20 +1,20 @@
 class Api::V1::Items::SearchController < ApplicationController
   respond_to :json
-  
+
   def index
     @items = Item.where(item_params)
     respond_with @items
   end
-  
+
   def show
     @item = Item.find_by(item_params)
     respond_with @item
   end
-  
-  private 
-  
+
+  private
+
   def item_params
-    params.require(:item).permit(
+    params.permit(
       :id,
       :name,
       :description,


### PR DESCRIPTION
- Remove `.require(:thing)` from the strong params in the search controllers for Items, Invoices, and Invoice Items to increase passing tests in spec harness
