### PR TITLE
Close #8 Close #9 Items and Invoice Items relationship endpoints

### DIFF
--- a/app/controllers/api/v1/invoice_items/invoices_controller.rb
+++ b/app/controllers/api/v1/invoice_items/invoices_controller.rb
@@ -1,0 +1,8 @@
+class Api::V1::InvoiceItems::InvoicesController < ApplicationController
+  respond_to :json
+
+  def show
+    @invoice = InvoiceItem.find(params[:id]).invoice
+    respond_with @invoice
+  end
+end

--- a/app/controllers/api/v1/invoice_items/items_controller.rb
+++ b/app/controllers/api/v1/invoice_items/items_controller.rb
@@ -1,0 +1,8 @@
+class Api::V1::InvoiceItems::ItemsController < ApplicationController
+  respond_to :json
+
+  def show
+    @item = InvoiceItem.find(params[:id]).item
+    respond_with @item
+  end
+end

--- a/app/controllers/api/v1/items/invoice_items_controller.rb
+++ b/app/controllers/api/v1/items/invoice_items_controller.rb
@@ -1,0 +1,8 @@
+class Api::V1::Items::InvoiceItemsController < ApplicationController
+  respond_to :json
+
+  def index
+    @invoice_items = Item.find(params[:id]).invoice_items
+    respond_with @invoice_items
+  end
+end

--- a/app/controllers/api/v1/items/merchants_controller.rb
+++ b/app/controllers/api/v1/items/merchants_controller.rb
@@ -1,0 +1,8 @@
+class Api::V1::Items::MerchantsController < ApplicationController
+  respond_to :json
+
+  def show
+    @merchant = Item.find(params[:id]).merchant
+    respond_with @merchant
+  end
+end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,8 +1,8 @@
 class Item < ApplicationRecord
   belongs_to :merchant
   has_many :invoice_items
-  has_many :items, through: :invoice_items
-  
+  has_many :invoices, through: :invoice_items
+
   validates :name, presence: true
   validates :description, presence: true
   validates :unit_price, presence: true

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -38,13 +38,17 @@ Rails.application.routes.draw do
         get '/find', to: 'search#show'
         get '/find_all', to: 'search#index'
         get '/random', to: 'random#show'
+        get '/:id/invoice_items', to: 'invoice_items#index'
+        get '/:id/merchant', to: 'merchants#show'
       end
       resources :items, only: [:index, :show]
-      
+
       namespace :invoice_items do
         get '/find', to: 'search#show'
         get '/find_all', to: 'search#index'
         get '/random', to: 'random#show'
+        get '/:id/invoice', to: 'invoices#show'
+        get '/:id/item', to: 'items#show'
       end
       resources :invoice_items, only: [:index, :show]
     end

--- a/spec/controllers/customers_controller_spec.rb
+++ b/spec/controllers/customers_controller_spec.rb
@@ -1,0 +1,35 @@
+require "rails_helper"
+
+RSpec.describe Api::V1::CustomersController do
+  describe "GET index" do
+    it "assigns all customers to @customers" do
+      10.times do
+        FactoryGirl.create(:customer)
+      end
+
+      get :index
+
+      expect(response.status).to eq(200)
+      expect(assigns(:customers).count).to eq(10)
+
+      customers = JSON.parse(response.body)
+
+      expect(customers.count).to eq(10)
+    end
+  end
+
+  describe "GET show" do
+    it "retrieves the correct @customer" do
+      FactoryGirl.create(:customer, id: 1, first_name: "Bill", last_name: "Burr")
+      FactoryGirl.create(:customer, id: 2, first_name: "Jerry", last_name: "Seinfeld")
+
+      get :show, params: { id: 1 }
+
+      expect(response.status).to eq(200)
+      expect(assigns(:customer).first_name).to eq("Bill")
+      expect(assigns(:customer).first_name).to_not eq("Jerry")
+      expect(assigns(:customer).last_name).to eq("Burr")
+      expect(assigns(:customer).last_name).to_not eq("Seinfeld")
+    end
+  end
+end

--- a/spec/controllers/customers_random_controller_spec.rb
+++ b/spec/controllers/customers_random_controller_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe Api::V1::Customers::RandomController do
+  describe "GET random" do
+    it "retrieves a random @customer" do
+      200.times do
+        FactoryGirl.create(:customer)
+      end
+
+      get :show
+      first_random_customer = assigns(:customer)
+
+      get :show
+      second_random_customer = assigns(:customer)
+
+      expect(first_random_customer).to_not eq(second_random_customer)
+      expect(response.status).to eq(200)
+
+      parsed_customer = JSON.parse(response.body)
+
+      expect(parsed_customer.class).to eq(Hash)
+      expect(parsed_customer.keys).to include("first_name", "last_name")
+    end
+  end
+end

--- a/spec/controllers/customers_search_controller_spec.rb
+++ b/spec/controllers/customers_search_controller_spec.rb
@@ -1,0 +1,51 @@
+require 'rails_helper'
+
+RSpec.describe Api::V1::Customers::SearchController do
+  describe "GET find_all?params" do
+    it "retrieves all customers correctly" do
+      10.times do
+        FactoryGirl.create(:customer, first_name: "Mitch", last_name: "Hedberg")
+      end
+
+      get :index, params: { first_name: "Mitch" }
+
+      expect(response.status).to eq(200)
+      expect(assigns(:customers).count).to eq(10)
+
+      parsed_customers = JSON.parse(response.body)
+
+      expect(parsed_customers.count).to eq(10)
+    end
+
+    it "retrieves only all matching customers correctly" do
+      2.times do
+        FactoryGirl.create(:customer, first_name: "Mitch", last_name: "Hedberg")
+      end
+
+      7.times do
+        FactoryGirl.create(:customer, first_name: "Kristen", last_name: "Wigg")
+      end
+
+      get :index, params: { first_name: "Kristen" }
+
+      expect(response.status).to eq(200)
+      expect(assigns(:customers).count).to eq(7)
+    end
+  end
+
+  describe "GET find?params" do
+    it "finds first search result correctly" do
+      5.times do |n|
+        FactoryGirl.create(:customer, id: "#{n+1}", first_name: "Chris", last_name: "Farley")
+      end
+
+      get :show, params: { first_name: "Chris" }
+
+      expect(response.status).to eq(200)
+      expect(assigns(:customer).class).to eq(Customer)
+      expect(assigns(:customer).id).to eq(1)
+      expect(assigns(:customer).first_name).to eq("Chris")
+      expect(assigns(:customer).last_name).to eq("Farley")
+    end
+  end
+end

--- a/spec/controllers/invoice_items_invoices_controller_spec.rb
+++ b/spec/controllers/invoice_items_invoices_controller_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+RSpec.describe Api::V1::InvoiceItems::InvoicesController do
+  describe "GET associated invoice" do
+    it "retrieves the correct invoice for that invoice_item" do
+      10.times do
+        FactoryGirl.create(:invoice)
+      end
+
+      FactoryGirl.create(
+        :invoice_item,
+        id: 1,
+        invoice: FactoryGirl.create(:invoice, id: 20)
+      )
+
+      get :show, params: { id: 1 }
+
+      expect(response.status).to eq(200)
+      expect(assigns(:invoice).id).to eq(20)
+    end
+
+    it "does not retrieve an invoice unrelated to that invoice_item" do
+      3.times do |n|
+        FactoryGirl.create(:invoice, id: "#{n+1}")
+      end
+
+      FactoryGirl.create(
+        :invoice_item,
+        id: 1,
+        invoice: FactoryGirl.create(:invoice)
+      )
+
+      get :show, params: { id: 1 }
+
+      expect(assigns(:invoice)).to_not be_within(1).of(2)
+    end
+  end
+end

--- a/spec/controllers/invoice_items_items_controller_spec.rb
+++ b/spec/controllers/invoice_items_items_controller_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+RSpec.describe Api::V1::InvoiceItems::ItemsController do
+  describe "GET associated item" do
+    it "retrieves the correct item for that invoice_item" do
+      10.times do
+        FactoryGirl.create(:item)
+      end
+
+      FactoryGirl.create(
+        :invoice_item,
+        id: 1,
+        item: FactoryGirl.create(:item, id: 20)
+      )
+
+      get :show, params: { id: 1 }
+
+      expect(response.status).to eq(200)
+      expect(assigns(:item).id).to eq(20)
+    end
+
+    it "does not retrieve an item unrelated to that invoice_item" do
+      3.times do |n|
+        FactoryGirl.create(:item, id: "#{n+1}")
+      end
+
+      FactoryGirl.create(
+        :invoice_item,
+        id: 1,
+        item: FactoryGirl.create(:item)
+      )
+
+      get :show, params: { id: 1 }
+
+      expect(assigns(:item)).to_not be_within(1).of(2)
+    end
+  end
+end

--- a/spec/controllers/invoice_items_search_controller_spec.rb
+++ b/spec/controllers/invoice_items_search_controller_spec.rb
@@ -6,35 +6,32 @@ RSpec.describe Api::V1::InvoiceItems::SearchController do
       10.times do
         FactoryGirl.create(:invoice_item, unit_price: 9.99)
       end
-      
-      get :index, params: {
-        invoice_item: { unit_price: 9.99 }
-      }
+
+      get :index, params: { unit_price: 9.99 }
+
       expect(assigns(:invoice_items).count).to eq(10)
     end
-    
+
     it "retrieves a subset of search results correctly" do
       5.times do
         FactoryGirl.create(:invoice_item, unit_price: 4.99)
         FactoryGirl.create(:invoice_item, unit_price: 100)
       end
-      
-      get :index, params: {
-        invoice_item: { unit_price: 100 }
-      }
+
+      get :index, params: { unit_price: 100 }
+
       expect(assigns(:invoice_items).count).to eq(5)
     end
   end
-  
+
   describe "GET find?params" do
     it "finds first search result correctly" do
       5.times do
         FactoryGirl.create(:invoice_item, unit_price: 50)
       end
-      
-      get :show, params: {
-        invoice_item: { unit_price: 50 }
-      }
+
+      get :show, params: { unit_price: 50 }
+
       expect(assigns(:invoice_item)).to be_a(InvoiceItem)
     end
   end

--- a/spec/controllers/invoices_search_controller_spec.rb
+++ b/spec/controllers/invoices_search_controller_spec.rb
@@ -6,35 +6,32 @@ RSpec.describe Api::V1::Invoices::SearchController do
       10.times do
         FactoryGirl.create(:invoice)
       end
-        
-      get :index, params: {
-        invoice: { status: "Rockin' and Rollin'" }
-      }
+
+      get :index, params: { status: "Rockin' and Rollin'" }
+
       expect(assigns(:invoices).count).to eq(10)
     end
-    
+
     it "retrieves a subset of search results correctly" do
       5.times do
         FactoryGirl.create(:invoice)
         FactoryGirl.create(:invoice, status: "Subset")
       end
-      
-      get :index, params: {
-        invoice: { status: "Subset" }
-      }
+
+      get :index, params: { status: "Subset" }
+
       expect(assigns(:invoices).count).to eq(5)
     end
   end
-  
+
   describe "GET find?params" do
     it "finds first search result correctly" do
       5.times do
         FactoryGirl.create(:invoice)
       end
-      
-      get :show, params: {
-        invoice: { status: "Rockin' and Rollin'" }
-      }
+
+      get :show, params: { status: "Rockin' and Rollin'" }
+
       expect(assigns(:invoice)).to be_a(Invoice)
     end
   end

--- a/spec/controllers/items_invoice_items_controller_spec.rb
+++ b/spec/controllers/items_invoice_items_controller_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+RSpec.describe Api::V1::Items::InvoiceItemsController do
+  describe "GET associated invoice_items" do
+    it "retrieves the correct invoice_items for that item" do
+      item = FactoryGirl.create(:item, id: 4)
+
+      10.times do
+        FactoryGirl.create(:invoice_item, item: item)
+      end
+
+      get :index, params: { id: 4 }
+
+      expect(response.status).to eq(200)
+      expect(assigns(:invoice_items).count).to eq(10)
+    end
+
+    it "does not retrieve invoice_items unrelated to that item" do
+      2.times do |n|
+        FactoryGirl.create(:item, id: "#{n+1}")
+      end
+
+      3.times do |n|
+        FactoryGirl.create(:invoice_item, item: Item.find(2))
+      end
+
+      get :index, params: { id: 1 }
+
+      expect(assigns(:invoice_items).count).to eq(0)
+    end
+  end
+end

--- a/spec/controllers/items_merchants_controller_spec.rb
+++ b/spec/controllers/items_merchants_controller_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+RSpec.describe Api::V1::Items::MerchantsController do
+  describe "GET associated merchant" do
+    it "retrieves the correct merchant for that item" do
+      10.times do
+        FactoryGirl.create(:merchant)
+      end
+
+      FactoryGirl.create(
+        :item,
+        id: 1,
+        merchant: FactoryGirl.create(:merchant, id: 20)
+      )
+
+      get :show, params: { id: 1 }
+
+      expect(response.status).to eq(200)
+      expect(assigns(:merchant).id).to eq(20)
+    end
+
+    it "does not retrieve a merchant unrelated to that item" do
+      3.times do |n|
+        FactoryGirl.create(:merchant, id: "#{n+1}")
+      end
+
+      FactoryGirl.create(
+        :item,
+        id: 1,
+        merchant: FactoryGirl.create(:merchant)
+      )
+
+      get :show, params: { id: 1 }
+
+      expect(assigns(:merchant)).to_not be_within(1).of(2)
+    end
+  end
+end

--- a/spec/controllers/items_search_controller_spec.rb
+++ b/spec/controllers/items_search_controller_spec.rb
@@ -6,35 +6,32 @@ RSpec.describe Api::V1::Items::SearchController do
       10.times do
         FactoryGirl.create(:item, unit_price: 9.99)
       end
-      
-      get :index, params: {
-        item: { unit_price: 9.99 }
-      }
+
+      get :index, params: { unit_price: 9.99 }
+
       expect(assigns(:items).count).to eq(10)
     end
-    
+
     it "retrieves a subset of search results correctly" do
       5.times do
         FactoryGirl.create(:item, unit_price: 5.99)
         FactoryGirl.create(:item, unit_price: 9.99)
       end
-      
-      get :index, params: {
-        item: { unit_price: 5.99 }
-      }
+
+      get :index, params: { unit_price: 5.99 }
+
       expect(assigns(:items).count).to eq(5)
     end
   end
-  
+
   describe "GET find?params" do
     it "finds first search result correctly" do
       5.times do
         FactoryGirl.create(:item, unit_price: 1.99)
       end
-      
-      get :show, params: {
-        item: { unit_price: 1.99 }
-      }
+
+      get :show, params: { unit_price: 1.99 }
+
       expect(assigns(:item)).to be_a(Item)
     end
   end

--- a/spec/controllers/merchants_controller_spec.rb
+++ b/spec/controllers/merchants_controller_spec.rb
@@ -1,0 +1,33 @@
+require "rails_helper"
+
+RSpec.describe Api::V1::MerchantsController do
+  describe "GET index" do
+    it "assigns all merchants to @merchants" do
+      8.times do
+        FactoryGirl.create(:merchant)
+      end
+
+      get :index
+
+      expect(response.status).to eq(200)
+      expect(assigns(:merchants).count).to eq(8)
+
+      merchants = JSON.parse(response.body)
+
+      expect(merchants.count).to eq(8)
+    end
+  end
+
+  describe "GET show" do
+    it "retrieves the correct @merchant" do
+      FactoryGirl.create(:merchant, id: 1, name: "Bill Hader")
+      FactoryGirl.create(:merchant, id: 2, name: "Andy Samberg")
+
+      get :show, params: { id: 2 }
+
+      expect(response.status).to eq(200)
+      expect(assigns(:merchant).name).to eq("Andy Samberg")
+      expect(assigns(:merchant).name).to_not eq("Bill Hader")
+    end
+  end
+end

--- a/spec/controllers/merchants_random_controller_spec.rb
+++ b/spec/controllers/merchants_random_controller_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe Api::V1::Merchants::RandomController do
+  describe "GET random" do
+    it "retrieves a random @merchant" do
+      200.times do
+        FactoryGirl.create(:merchant)
+      end
+
+      get :show
+      first_random_merchant = assigns(:merchant)
+
+      get :show
+      second_random_merchant = assigns(:merchant)
+
+      expect(first_random_merchant).to_not eq(second_random_merchant)
+      expect(response.status).to eq(200)
+
+      parsed_merchant = JSON.parse(response.body)
+
+      expect(parsed_merchant.class).to eq(Hash)
+      expect(parsed_merchant.keys).to include("name")
+    end
+  end
+end

--- a/spec/controllers/merchants_search_controller_spec.rb
+++ b/spec/controllers/merchants_search_controller_spec.rb
@@ -1,0 +1,50 @@
+require 'rails_helper'
+
+RSpec.describe Api::V1::Merchants::SearchController do
+  describe "GET find_all?params" do
+    it "retrieves all merchants correctly" do
+      10.times do
+        FactoryGirl.create(:merchant, name: "Melissa McCarthy")
+      end
+
+      get :index, params: { name: "Melissa McCarthy" }
+
+      expect(response.status).to eq(200)
+      expect(assigns(:merchants).count).to eq(10)
+
+      parsed_merchants = JSON.parse(response.body)
+
+      expect(parsed_merchants.count).to eq(10)
+    end
+
+    it "retrieves only all matching merchants correctly" do
+      2.times do
+        FactoryGirl.create(:merchant, name: "Melissa McCarthy")
+      end
+
+      7.times do
+        FactoryGirl.create(:merchant, name: "Eddie Murphy")
+      end
+
+      get :index, params: { name: "Eddie Murphy" }
+
+      expect(response.status).to eq(200)
+      expect(assigns(:merchants).count).to eq(7)
+    end
+  end
+
+  describe "GET find?params" do
+    it "finds first search result correctly" do
+      5.times do |n|
+        FactoryGirl.create(:merchant, id: "#{n+1}", name: "Martin Short")
+      end
+
+      get :show, params: { name: "Martin Short" }
+
+      expect(response.status).to eq(200)
+      expect(assigns(:merchant).class).to eq(Merchant)
+      expect(assigns(:merchant).id).to eq(1)
+      expect(assigns(:merchant).name).to eq("Martin Short")
+    end
+  end
+end

--- a/spec/controllers/transactions_controller_spec.rb
+++ b/spec/controllers/transactions_controller_spec.rb
@@ -1,0 +1,45 @@
+require "rails_helper"
+
+RSpec.describe Api::V1::TransactionsController do
+  describe "GET index" do
+    it "assigns all transactions to @transactions" do
+      9.times do
+        FactoryGirl.create(:transaction)
+      end
+
+      get :index
+
+      expect(response.status).to eq(200)
+      expect(assigns(:transactions).count).to eq(9)
+
+      transactions = JSON.parse(response.body)
+
+      expect(transactions.count).to eq(9)
+    end
+  end
+
+  describe "GET show" do
+    it "retrieves the correct @transaction" do
+      FactoryGirl.create(
+        :transaction,
+        id: 1,
+        credit_card_number: "4242424242424242",
+        result: "success"
+      )
+      FactoryGirl.create(
+        :transaction,
+        id: 2,
+        credit_card_number: "0101010101010101",
+        result: "failed"
+      )
+
+      get :show, params: { id: 1 }
+
+      expect(response.status).to eq(200)
+      expect(assigns(:transaction).credit_card_number).to eq("4242424242424242")
+      expect(assigns(:transaction).credit_card_number).to_not eq("0101010101010101")
+      expect(assigns(:transaction).result).to eq("success")
+      expect(assigns(:transaction).result).to_not eq("failed")
+    end
+  end
+end

--- a/spec/controllers/transactions_random_controller_spec.rb
+++ b/spec/controllers/transactions_random_controller_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe Api::V1::Transactions::RandomController do
+  describe "GET random" do
+    it "retrieves a random @transaction" do
+      200.times do
+        FactoryGirl.create(:transaction)
+      end
+
+      get :show
+      first_random_transaction = assigns(:transaction)
+
+      get :show
+      second_random_transaction = assigns(:transaction)
+
+      expect(first_random_transaction).to_not eq(second_random_transaction)
+      expect(response.status).to eq(200)
+
+      parsed_transaction = JSON.parse(response.body)
+
+      expect(parsed_transaction.class).to eq(Hash)
+      expect(parsed_transaction.keys).to include("credit_card_number", "result")
+    end
+  end
+end

--- a/spec/controllers/transactions_search_controller_spec.rb
+++ b/spec/controllers/transactions_search_controller_spec.rb
@@ -1,0 +1,50 @@
+require 'rails_helper'
+
+RSpec.describe Api::V1::Transactions::SearchController do
+  describe "GET find_all?params" do
+    it "retrieves all transactions correctly" do
+      10.times do
+        FactoryGirl.create(:transaction, credit_card_number: "0101010101010101")
+      end
+
+      get :index, params: { credit_card_number: "0101010101010101" }
+
+      expect(response.status).to eq(200)
+      expect(assigns(:transactions).count).to eq(10)
+
+      parsed_transactions = JSON.parse(response.body)
+
+      expect(parsed_transactions.count).to eq(10)
+    end
+
+    it "retrieves only all matching transactions correctly" do
+      2.times do
+        FactoryGirl.create(:transaction, credit_card_number: "0101010101010101")
+      end
+
+      7.times do
+        FactoryGirl.create(:transaction, credit_card_number: "4242424242424242")
+      end
+
+      get :index, params: { credit_card_number: "4242424242424242" }
+
+      expect(response.status).to eq(200)
+      expect(assigns(:transactions).count).to eq(7)
+    end
+  end
+
+  describe "GET find?params" do
+    it "finds first search result correctly" do
+      5.times do |n|
+        FactoryGirl.create(:transaction, id: "#{n+1}", credit_card_number: "9797979797979797")
+      end
+
+      get :show, params: { credit_card_number: "9797979797979797" }
+
+      expect(response.status).to eq(200)
+      expect(assigns(:transaction).class).to eq(Transaction)
+      expect(assigns(:transaction).id).to eq(1)
+      expect(assigns(:transaction).credit_card_number).to eq("9797979797979797")
+    end
+  end
+end

--- a/spec/factories/transactions.rb
+++ b/spec/factories/transactions.rb
@@ -1,0 +1,9 @@
+FactoryGirl.define do
+  factory :transaction do
+    invoice { FactoryGirl.create(:invoice) }
+    credit_card_number { rand(10 ** 16) }
+    result { ['success', 'failed'].sample }
+    created_at { 1.year.ago }
+    updated_at { DateTime.now }
+  end
+end

--- a/spec/models/customer_spec.rb
+++ b/spec/models/customer_spec.rb
@@ -2,9 +2,9 @@ require 'rails_helper'
 
 RSpec.describe Customer, type: :model do
   it "has a valid factory" do
-    invoice = FactoryGirl.create(:customer)
+    customer = FactoryGirl.create(:customer)
 
-    expect(invoice).to be_valid
+    expect(customer).to be_valid
   end
 
   it { should have_many :invoices }

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -2,9 +2,9 @@ require 'rails_helper'
 
 RSpec.describe Merchant, type: :model do
   it "has a valid factory" do
-    invoice = FactoryGirl.create(:merchant)
+    merchant = FactoryGirl.create(:merchant)
 
-    expect(invoice).to be_valid
+    expect(merchant).to be_valid
   end
 
   it { should have_many :items }

--- a/spec/models/transaction_spec.rb
+++ b/spec/models/transaction_spec.rb
@@ -2,9 +2,9 @@ require 'rails_helper'
 
 RSpec.describe Transaction, type: :model do
   it "has a valid factory" do
-    invoice = FactoryGirl.create(:customer)
+    transaction = FactoryGirl.create(:transaction)
 
-    expect(invoice).to be_valid
+    expect(transaction).to be_valid
   end
 
   it { should belong_to :invoice }


### PR DESCRIPTION
@concach See below for the changes made. All spec harness tests for the two relationships (item and invoice_item) are currently passing, as well as all of our own tests.
- Create InvoiceItems controller (and spec) for InvoiceItems->Invoices relationship
- Create InvoiceItems controller (and spec) for InvoiceItems->Items relationship
- Create Items controller (and spec) for Items->InvoiceItems relationship
- Create Items controller (and spec) for Items->Merchants relationship
- Update items_search, invoices_search, & invoice_items_search specs to reflect change to strong params in controllers
- Update routes to include relationship endpoints for InvoiceItems and Items
- Fix `has_many` error in Item model (item.rb)
