### PR TITLE
Implement best_day BI endpoint

### DIFF
--- a/app/controllers/api/v1/customers/transactions_controller.rb
+++ b/app/controllers/api/v1/customers/transactions_controller.rb
@@ -1,12 +1,8 @@
 class Api::V1::Customers::TransactionsController < ApplicationController
   respond_to :json
-  
+
   def index
-    invoices = Invoice.where(customer_id: params[:id])
-    @transactions = []
-    invoices.each do |invoice|
-      @transactions << Transaction.where(invoice_id: invoice.id)
-    end
-    @transactions = @transactions.flatten
+    @transactions = Customer.find(params[:id]).transactions
+    respond_with @transactions
   end
 end

--- a/app/controllers/api/v1/items/best_day_controller.rb
+++ b/app/controllers/api/v1/items/best_day_controller.rb
@@ -1,0 +1,8 @@
+class Api::V1::Items::BestDayController < ApplicationController
+  respond_to :json
+
+  def show
+    @best_day = Item.find(params[:id]).best_day
+    respond_with @best_day, serializer: BestDaySerializer
+  end
+end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -9,4 +9,11 @@ class Item < ApplicationRecord
   validates :merchant_id, presence: true
   validates :created_at, presence: true
   validates :updated_at, presence: true
+
+  def best_day
+    invoice_items.joins(:invoice)
+      .group("invoices.created_at")
+      .order("sum_invoice_items_quantity DESC, invoices_created_at DESC")
+      .sum("invoice_items.quantity").first.first
+  end
 end

--- a/app/serializers/best_day_serializer.rb
+++ b/app/serializers/best_day_serializer.rb
@@ -1,0 +1,7 @@
+class BestDaySerializer < ActiveModel::Serializer
+  attributes :best_day
+
+  def best_day
+    object.strftime("%FT%T.%LZ")
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -45,6 +45,7 @@ Rails.application.routes.draw do
         get '/random', to: 'random#show'
         get '/:id/invoice_items', to: 'invoice_items#index'
         get '/:id/merchant', to: 'merchants#show'
+        get '/:id/best_day', to: 'best_day#show'
       end
       resources :items, only: [:index, :show]
 

--- a/spec/controllers/items/items_best_day_controller_spec.rb
+++ b/spec/controllers/items/items_best_day_controller_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe Api::V1::Items::BestDayController do
+  describe "GET best day" do
+    it "retrieves the date with the most sales for that item" do
+      item = FactoryGirl.create(:item)
+
+      invoice_1 = FactoryGirl.create(:invoice, created_at: "2015-03-23T12:53:59.000Z")
+      invoice_2 = FactoryGirl.create(:invoice, created_at: "2014-02-23T12:53:59.000Z")
+      invoice_3 = FactoryGirl.create(:invoice, created_at: "2013-01-23T12:53:59.000Z")
+
+      invoice_item_1 = FactoryGirl.create(:invoice_item, invoice: invoice_1, item: item, quantity: 1)
+      invoice_item_2 = FactoryGirl.create(:invoice_item, invoice: invoice_2, item: item, quantity: 2)
+      invoice_item_3 = FactoryGirl.create(:invoice_item, invoice: invoice_3, item: item, quantity: 4)
+
+      get :show, params: { id: item.id }
+
+      expect(response.status).to eq(200)
+
+      parsed_best_day = JSON.parse(response.body)
+
+      expect(parsed_best_day["best_day"]).to eq("2013-01-23T12:53:59.000Z")
+    end
+  end
+end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -3,15 +3,31 @@ require 'rails_helper'
 RSpec.describe Item, type: :model do
   it "has a valid factory" do
     item = FactoryGirl.create(:item)
-    
+
     expect(item).to be_valid
   end
-  
+
+  it { should belong_to :merchant }
+  it { should have_many :invoice_items }
+  it { should have_many :invoices }
   it { should validate_presence_of :name }
   it { should validate_presence_of :description }
   it { should validate_presence_of :unit_price }
-  it { should belong_to :merchant }
   it { should validate_presence_of :merchant_id }
   it { should validate_presence_of :created_at }
   it { should validate_presence_of :updated_at }
+
+  it "calculates best day for item" do
+    item = FactoryGirl.create(:item)
+
+    invoice_1 = FactoryGirl.create(:invoice, created_at: "2015-03-23T12:53:59.000Z")
+    invoice_2 = FactoryGirl.create(:invoice, created_at: "2014-02-23T12:53:59.000Z")
+    invoice_3 = FactoryGirl.create(:invoice, created_at: "2013-01-23T12:53:59.000Z")
+
+    invoice_item_1 = FactoryGirl.create(:invoice_item, invoice: invoice_1, item: item, quantity: 1)
+    invoice_item_2 = FactoryGirl.create(:invoice_item, invoice: invoice_2, item: item, quantity: 2)
+    invoice_item_3 = FactoryGirl.create(:invoice_item, invoice: invoice_3, item: item, quantity: 4)
+
+    expect(item.best_day).to eq("2013-01-23T12:53:59.000Z")
+  end
 end


### PR DESCRIPTION
Currently passing all our own tests, as well as the relevant spec_harness test for best_day.
- Create best_day method in Item model (and spec) to calculate & return best day
- Create BestDaySerializer to return date in the weird format required by the spec harness
- Create Items controller (and spec) for Items->BestDay BI endpoint
- Update routes to include best_day BI endpoint for Items
- Refactor index method in customers/transactions_controller
