### PR TITLE
Implement favorite_merchant BI endpoint for Customers

### DIFF
--- a/app/controllers/api/v1/customers/favorite_merchant_controller.rb
+++ b/app/controllers/api/v1/customers/favorite_merchant_controller.rb
@@ -1,0 +1,8 @@
+class Api::V1::Customers::FavoriteMerchantController < ApplicationController
+  respond_to :json
+
+  def show
+    @favorite_merchant = Customer.find(params[:id]).favorite_merchant
+    respond_with @favorite_merchant
+  end
+end

--- a/app/controllers/api/v1/items/most_items_controller.rb
+++ b/app/controllers/api/v1/items/most_items_controller.rb
@@ -2,7 +2,7 @@ class Api::V1::Items::MostItemsController < ApplicationController
   respond_to :json
 
   def index
-    @most_items = Item.most_items(params[:quantity].to_i)
+    @most_items = Item.most_items(params[:quantity])
     respond_with @most_items
   end
 end

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -1,9 +1,17 @@
 class Customer < ApplicationRecord
   has_many :invoices
   has_many :transactions, through: :invoices
+  has_many :merchants, through: :invoices
 
   validates :first_name, presence: true
   validates :last_name, presence: true
   validates :created_at, presence: true
   validates :updated_at, presence: true
+
+  def favorite_merchant
+    merchants.joins(invoices: :transactions)
+      .where(transactions: {result: "success"})
+      .group(:id)
+      .order("count(invoices.merchant_id) DESC").first
+  end
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -12,7 +12,7 @@ class Item < ApplicationRecord
 
   def self.most_items(quantity)
     joins(:invoice_items)
-      .group("items.id")
+      .group(:id)
       .order("sum(invoice_items.quantity) DESC")
       .limit(quantity)
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -40,6 +40,7 @@ Rails.application.routes.draw do
         get '/random', to: 'random#show'
         get '/:id/invoices', to: 'invoices#index'
         get '/:id/transactions', to: 'transactions#index'
+        get '/:id/favorite_merchant', to: 'favorite_merchant#show'
       end
       resources :customers, only: [:index, :show]
 

--- a/spec/controllers/customers/customers_favorite_merchant_controller_spec.rb
+++ b/spec/controllers/customers/customers_favorite_merchant_controller_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe Api::V1::Customers::FavoriteMerchantController do
+  describe "GET favorite merchant" do
+    it "retrieves favorite merchant for that customer" do
+      customer = FactoryGirl.create(:customer)
+
+      merchant_1, merchant_2 = create_list(:merchant, 2)
+
+      3.times do |i|
+        if i < 2
+          invoice = FactoryGirl.create(:invoice,
+                                       customer: customer,
+                                       merchant: merchant_1)
+          FactoryGirl.create(:transaction, invoice: invoice)
+        else
+          invoice = FactoryGirl.create(:invoice,
+                                       customer: customer,
+                                       merchant: merchant_2)
+          FactoryGirl.create(:transaction, invoice: invoice)
+        end
+      end
+
+      get :show, params: { id: customer.id }
+
+      expect(response.status).to eq(200)
+
+      parsed_favorite_merchant = JSON.parse(response.body)
+
+      expect(parsed_favorite_merchant["id"]).to eq(merchant_1.id)
+    end
+  end
+end

--- a/spec/controllers/merchants/customers_pending_invoices_controller_spec.rb
+++ b/spec/controllers/merchants/customers_pending_invoices_controller_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Api::V1::Merchants::CustomersPendingInvoicesController do
     it "retrieves the customers with pending invoices" do
       m = FactoryGirl.create(:merchant, id: 1)
       cust_1 = FactoryGirl.create(:customer, id: 1)
-      inv_1 = FactoryGirl.create(:invoice, 
+      inv_1 = FactoryGirl.create(:invoice,
         customer: cust_1,
         merchant: m
       )
@@ -14,7 +14,7 @@ RSpec.describe Api::V1::Merchants::CustomersPendingInvoicesController do
         result: "failed"
       )
       cust_2 = FactoryGirl.create(:customer, id: 2)
-      inv_2 = FactoryGirl.create(:invoice, 
+      inv_2 = FactoryGirl.create(:invoice,
         customer: cust_2,
         merchant: m
       )
@@ -23,7 +23,7 @@ RSpec.describe Api::V1::Merchants::CustomersPendingInvoicesController do
         result: "failed"
       )
       cust_3 = FactoryGirl.create(:customer, id: 3)
-      inv_3 = FactoryGirl.create(:invoice, 
+      inv_3 = FactoryGirl.create(:invoice,
         customer: cust_3,
         merchant: m
       )
@@ -31,16 +31,16 @@ RSpec.describe Api::V1::Merchants::CustomersPendingInvoicesController do
         invoice: inv_3,
         result: "failed"
       )
-      
-      get :index, id: 1
-      
+
+      get :index, params: { id: 1 }
+
       result = JSON.parse(response.body)
       expect(result.count).to eq(3)
       expect(OpenStruct.new(result[0]).id).to eq(1)
       expect(OpenStruct.new(result[1]).id).to eq(2)
       expect(OpenStruct.new(result[2]).id).to eq(3)
     end
-    
+
     it "does not retrieve customers with no pending invoices" do
       m = FactoryGirl.create(:merchant, id: 1)
       cust_1 = FactoryGirl.create(:customer, id: 1)
@@ -53,7 +53,7 @@ RSpec.describe Api::V1::Merchants::CustomersPendingInvoicesController do
         result: "failed"
       )
       cust_2 = FactoryGirl.create(:customer, id: 2)
-      inv_2 = FactoryGirl.create(:invoice, 
+      inv_2 = FactoryGirl.create(:invoice,
         merchant: m,
         customer: cust_2
       )
@@ -61,9 +61,9 @@ RSpec.describe Api::V1::Merchants::CustomersPendingInvoicesController do
         invoice: inv_2,
         result: "success"
       )
-      
-      get :index, id: 1
-      
+
+      get :index, params: { id: 1 }
+
       result = JSON.parse(response.body)
       expect(result.count).to eq(1)
       expect(OpenStruct.new(result[0]).id).to eq(1)

--- a/spec/controllers/merchants/favorite_customers_controller_spec.rb
+++ b/spec/controllers/merchants/favorite_customers_controller_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Api::V1::Merchants::FavoriteCustomersController do
     it "retrieves the customer with the most total number of successful transactions" do
       m = FactoryGirl.create(:merchant, id: 1)
       cust_1 = FactoryGirl.create(:customer, id: 1)
-      inv_1 = FactoryGirl.create(:invoice, 
+      inv_1 = FactoryGirl.create(:invoice,
         customer: cust_1,
         merchant: m,
       )
@@ -14,7 +14,7 @@ RSpec.describe Api::V1::Merchants::FavoriteCustomersController do
         result: "success"
       )
       cust_2 = FactoryGirl.create(:customer, id: 2)
-      inv_2 = FactoryGirl.create(:invoice, 
+      inv_2 = FactoryGirl.create(:invoice,
         customer: cust_2,
         merchant: m
       )
@@ -30,9 +30,9 @@ RSpec.describe Api::V1::Merchants::FavoriteCustomersController do
         invoice: inv_3,
         result: "success"
       )
-      
-      get :show, id: 1
-      
+
+      get :show, params: { id: 1 }
+
       result = JSON.parse(response.body)
       expect(OpenStruct.new(result).id).to eq(2)
     end

--- a/spec/controllers/merchants/revenue_controller_spec.rb
+++ b/spec/controllers/merchants/revenue_controller_spec.rb
@@ -5,20 +5,20 @@ RSpec.describe Api::V1::Merchants::RevenueController do
     it "retrieves the top x merchants by total revenue" do
       merchant_1 = FactoryGirl.create(:merchant, id: 1)
       merchant_1_items = []
-      20.times do 
+      20.times do
         merchant_1_items << FactoryGirl.create(:item, merchant: merchant_1)
       end
       customer = FactoryGirl.create(:customer, id: 1)
       merchant_1_invoices = []
       5.times do |n|
-        merchant_1_invoices << FactoryGirl.create(:invoice, 
+        merchant_1_invoices << FactoryGirl.create(:invoice,
           id: n,
-          customer: customer, 
+          customer: customer,
           merchant: merchant_1
         )
       end
       merchant_1_items.each do |item|
-        FactoryGirl.create(:invoice_item, 
+        FactoryGirl.create(:invoice_item,
           invoice: merchant_1_invoices.sample,
           item: item
         )
@@ -28,22 +28,22 @@ RSpec.describe Api::V1::Merchants::RevenueController do
       merchant_2_invoice = FactoryGirl.create(:invoice,
         customer: customer,
         merchant: merchant_2
-      )  
-      FactoryGirl.create(:invoice_item, 
-        invoice: merchant_2_invoice, 
+      )
+      FactoryGirl.create(:invoice_item,
+        invoice: merchant_2_invoice,
         item: merchant_2_item
       )
       merchant_3 = FactoryGirl.create(:merchant, id: 3)
-      
+
       get :index, params: { quantity: 3 }
-      
+
       result = JSON.parse(response.body)
       expect(OpenStruct.new(result[0]).id).to eq(1)
       expect(OpenStruct.new(result[1]).id).to eq(2)
       expect(OpenStruct.new(result[2]).id).to eq(3)
     end
   end
-  
+
   describe "GET /:id/revenue" do
     it "returns the total revenue for that merchant across all transactions" do
       m = FactoryGirl.create(:merchant, id: 1)
@@ -63,56 +63,55 @@ RSpec.describe Api::V1::Merchants::RevenueController do
         quantity: 3,
         unit_price: 100.00
       )
-      
-      get :show, id: 1
+
+      get :show, params: { id: 1 }
       expect(JSON.parse(response.body)).to eq(500.0)
     end
   end
-  
+
   describe "GET revenue?date=x" do
     it "retrieves the total revenue across date x for all merchants" do
       m1 = FactoryGirl.create(:merchant)
       m1_item = FactoryGirl.create(:item, merchant: m1)
       m1_inv = FactoryGirl.create(:invoice, merchant: m1)
-      m1_ii = FactoryGirl.create(:invoice_item, 
+      m1_ii = FactoryGirl.create(:invoice_item,
         invoice: m1_inv, item: m1_item, quantity: 10, unit_price: 10)
-      m1_it = FactoryGirl.create(:transaction, 
+      m1_it = FactoryGirl.create(:transaction,
         invoice: m1_inv, updated_at: "3/3/2003", result: "success")
       m2 = FactoryGirl.create(:merchant)
       m2_item = FactoryGirl.create(:item, merchant: m2)
       m2_inv = FactoryGirl.create(:invoice, merchant: m2)
-      m2_ii = FactoryGirl.create(:invoice_item, 
+      m2_ii = FactoryGirl.create(:invoice_item,
         invoice: m2_inv, item: m2_item, quantity: 5, unit_price: 5)
-      m2_it = FactoryGirl.create(:transaction, 
+      m2_it = FactoryGirl.create(:transaction,
         invoice: m2_inv, updated_at: "3/3/2003", result: "success")
 
       get :date, params: { date: "3/3/2003" }
-      
+
       result = response.body
       expect(result).to eq("125.00")
     end
   end
-  
+
   describe "GET :id/revenue?date=x" do
     it "retrieves the total revenue across date x for that merchant" do
       m = FactoryGirl.create(:merchant, id: 1)
       item = FactoryGirl.create(:item, merchant: m)
       invoice_1 = FactoryGirl.create(:invoice, merchant: m)
-      invoice_item_1 = FactoryGirl.create(:invoice_item, 
+      invoice_item_1 = FactoryGirl.create(:invoice_item,
         invoice: invoice_1, item: item, quantity: 10, unit_price: 10)
-      invoice_transaction_1 = FactoryGirl.create(:transaction, 
+      invoice_transaction_1 = FactoryGirl.create(:transaction,
         invoice: invoice_1, updated_at: "3/3/2003", result: "success")
       invoice_2 = FactoryGirl.create(:invoice, merchant: m)
-      invoice_item_2 = FactoryGirl.create(:invoice_item, 
+      invoice_item_2 = FactoryGirl.create(:invoice_item,
         invoice: invoice_2, item: item, quantity: 5, unit_price: 5)
-      invoice_transaction_2 = FactoryGirl.create(:transaction, 
+      invoice_transaction_2 = FactoryGirl.create(:transaction,
         invoice: invoice_2, updated_at: "3/3/2003", result: "success")
 
       get :show, params: { id: 1, date: "3/3/2003" }
-      
+
       result = response.body
       expect(result).to eq("125.00")
     end
   end
 end
-      

--- a/spec/models/customer_spec.rb
+++ b/spec/models/customer_spec.rb
@@ -9,8 +9,31 @@ RSpec.describe Customer, type: :model do
 
   it { should have_many :invoices }
   it { should have_many :transactions }
+  it { should have_many :merchants }
   it { should validate_presence_of :first_name }
   it { should validate_presence_of :last_name }
   it { should validate_presence_of :created_at }
   it { should validate_presence_of :updated_at }
+
+  it "returns the customer's favorite merchant" do
+    customer = FactoryGirl.create(:customer)
+
+    merchant_1, merchant_2 = create_list(:merchant, 2)
+
+    3.times do |i|
+      if i < 2
+        invoice = FactoryGirl.create(:invoice,
+                                     customer: customer,
+                                     merchant: merchant_1)
+        FactoryGirl.create(:transaction, invoice: invoice)
+      else
+        invoice = FactoryGirl.create(:invoice,
+                                     customer: customer,
+                                     merchant: merchant_2)
+        FactoryGirl.create(:transaction, invoice: invoice)
+      end
+    end
+
+    expect(customer.favorite_merchant).to eq(merchant_1)
+  end
 end


### PR DESCRIPTION
- Create favorite_merchant method in Customer model (and spec) to return most frequented merchant
- Create Customers controller (and spec) for Customers->FavoriteMerchant BI endpoint
- Update routes to include favorite_merchant BI endpoint for customers
- Refactor Item model to be less verbose
- Remove `.to_i` method from `items/most_items_controller` since ActiveRecord apparently handles this automatically
- Fix deprecation warning that appears when running rspec
